### PR TITLE
Add the docs folder and update the replacement strategy from create_then_delete to delete_then_create

### DIFF
--- a/aws-kafkaconnect-connector/aws-kafkaconnect-connector.json
+++ b/aws-kafkaconnect-connector/aws-kafkaconnect-connector.json
@@ -454,6 +454,7 @@
   "readOnlyProperties": [
     "/properties/ConnectorArn"
   ],
+  "replacementStrategy": "delete_then_create",
   "createOnlyProperties": [
     "/properties/ConnectorConfiguration",
     "/properties/ConnectorDescription",

--- a/aws-kafkaconnect-connector/docs/README.md
+++ b/aws-kafkaconnect-connector/docs/README.md
@@ -1,0 +1,196 @@
+# AWS::KafkaConnect::Connector
+
+Resource Type definition for AWS::KafkaConnect::Connector
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "Type" : "AWS::KafkaConnect::Connector",
+    "Properties" : {
+        "<a href="#capacity" title="Capacity">Capacity</a>" : <i><a href="capacity.md">Capacity</a></i>,
+        "<a href="#connectorconfiguration" title="ConnectorConfiguration">ConnectorConfiguration</a>" : <i><a href="connectorconfiguration.md">ConnectorConfiguration</a></i>,
+        "<a href="#connectordescription" title="ConnectorDescription">ConnectorDescription</a>" : <i>String</i>,
+        "<a href="#connectorname" title="ConnectorName">ConnectorName</a>" : <i>String</i>,
+        "<a href="#kafkacluster" title="KafkaCluster">KafkaCluster</a>" : <i><a href="kafkacluster.md">KafkaCluster</a></i>,
+        "<a href="#kafkaclusterclientauthentication" title="KafkaClusterClientAuthentication">KafkaClusterClientAuthentication</a>" : <i><a href="kafkaclusterclientauthentication.md">KafkaClusterClientAuthentication</a></i>,
+        "<a href="#kafkaclusterencryptionintransit" title="KafkaClusterEncryptionInTransit">KafkaClusterEncryptionInTransit</a>" : <i><a href="kafkaclusterencryptionintransit.md">KafkaClusterEncryptionInTransit</a></i>,
+        "<a href="#kafkaconnectversion" title="KafkaConnectVersion">KafkaConnectVersion</a>" : <i>String</i>,
+        "<a href="#logdelivery" title="LogDelivery">LogDelivery</a>" : <i><a href="logdelivery.md">LogDelivery</a></i>,
+        "<a href="#plugins" title="Plugins">Plugins</a>" : <i>[ <a href="plugin.md">Plugin</a>, ... ]</i>,
+        "<a href="#serviceexecutionrolearn" title="ServiceExecutionRoleArn">ServiceExecutionRoleArn</a>" : <i>String</i>,
+        "<a href="#workerconfiguration" title="WorkerConfiguration">WorkerConfiguration</a>" : <i><a href="workerconfiguration.md">WorkerConfiguration</a></i>
+    }
+}
+</pre>
+
+### YAML
+
+<pre>
+Type: AWS::KafkaConnect::Connector
+Properties:
+    <a href="#capacity" title="Capacity">Capacity</a>: <i><a href="capacity.md">Capacity</a></i>
+    <a href="#connectorconfiguration" title="ConnectorConfiguration">ConnectorConfiguration</a>: <i><a href="connectorconfiguration.md">ConnectorConfiguration</a></i>
+    <a href="#connectordescription" title="ConnectorDescription">ConnectorDescription</a>: <i>String</i>
+    <a href="#connectorname" title="ConnectorName">ConnectorName</a>: <i>String</i>
+    <a href="#kafkacluster" title="KafkaCluster">KafkaCluster</a>: <i><a href="kafkacluster.md">KafkaCluster</a></i>
+    <a href="#kafkaclusterclientauthentication" title="KafkaClusterClientAuthentication">KafkaClusterClientAuthentication</a>: <i><a href="kafkaclusterclientauthentication.md">KafkaClusterClientAuthentication</a></i>
+    <a href="#kafkaclusterencryptionintransit" title="KafkaClusterEncryptionInTransit">KafkaClusterEncryptionInTransit</a>: <i><a href="kafkaclusterencryptionintransit.md">KafkaClusterEncryptionInTransit</a></i>
+    <a href="#kafkaconnectversion" title="KafkaConnectVersion">KafkaConnectVersion</a>: <i>String</i>
+    <a href="#logdelivery" title="LogDelivery">LogDelivery</a>: <i><a href="logdelivery.md">LogDelivery</a></i>
+    <a href="#plugins" title="Plugins">Plugins</a>: <i>
+      - <a href="plugin.md">Plugin</a></i>
+    <a href="#serviceexecutionrolearn" title="ServiceExecutionRoleArn">ServiceExecutionRoleArn</a>: <i>String</i>
+    <a href="#workerconfiguration" title="WorkerConfiguration">WorkerConfiguration</a>: <i><a href="workerconfiguration.md">WorkerConfiguration</a></i>
+</pre>
+
+## Properties
+
+#### Capacity
+
+Information about the capacity allocated to the connector.
+
+_Required_: Yes
+
+_Type_: <a href="capacity.md">Capacity</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### ConnectorConfiguration
+
+The configuration for the connector.
+
+_Required_: Yes
+
+_Type_: <a href="connectorconfiguration.md">ConnectorConfiguration</a>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### ConnectorDescription
+
+A summary description of the connector.
+
+_Required_: No
+
+_Type_: String
+
+_Maximum Length_: <code>1024</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### ConnectorName
+
+The name of the connector.
+
+_Required_: Yes
+
+_Type_: String
+
+_Minimum Length_: <code>1</code>
+
+_Maximum Length_: <code>128</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### KafkaCluster
+
+Details of how to connect to the Kafka cluster.
+
+_Required_: Yes
+
+_Type_: <a href="kafkacluster.md">KafkaCluster</a>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### KafkaClusterClientAuthentication
+
+Details of the client authentication used by the Kafka cluster.
+
+_Required_: Yes
+
+_Type_: <a href="kafkaclusterclientauthentication.md">KafkaClusterClientAuthentication</a>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### KafkaClusterEncryptionInTransit
+
+Details of encryption in transit to the Kafka cluster.
+
+_Required_: Yes
+
+_Type_: <a href="kafkaclusterencryptionintransit.md">KafkaClusterEncryptionInTransit</a>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### KafkaConnectVersion
+
+The version of Kafka Connect. It has to be compatible with both the Kafka cluster's version and the plugins.
+
+_Required_: Yes
+
+_Type_: String
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### LogDelivery
+
+Details of what logs are delivered and where they are delivered.
+
+_Required_: No
+
+_Type_: <a href="logdelivery.md">LogDelivery</a>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### Plugins
+
+List of plugins to use with the connector.
+
+_Required_: Yes
+
+_Type_: List of <a href="plugin.md">Plugin</a>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### ServiceExecutionRoleArn
+
+The Amazon Resource Name (ARN) of the IAM role used by the connector to access Amazon S3 objects and other external resources.
+
+_Required_: Yes
+
+_Type_: String
+
+_Pattern_: <code>arn:(aws|aws-us-gov|aws-cn):iam:.*</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### WorkerConfiguration
+
+Specifies the worker configuration to use with the connector.
+
+_Required_: No
+
+_Type_: <a href="workerconfiguration.md">WorkerConfiguration</a>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+## Return Values
+
+### Ref
+
+When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the ConnectorArn.
+
+### Fn::GetAtt
+
+The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of this type. The following are the available attributes and sample return values.
+
+For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
+
+#### ConnectorArn
+
+Amazon Resource Name for the created Connector.
+

--- a/aws-kafkaconnect-connector/docs/README.md
+++ b/aws-kafkaconnect-connector/docs/README.md
@@ -193,4 +193,3 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 #### ConnectorArn
 
 Amazon Resource Name for the created Connector.
-

--- a/aws-kafkaconnect-connector/docs/apachekafkacluster.md
+++ b/aws-kafkaconnect-connector/docs/apachekafkacluster.md
@@ -43,4 +43,3 @@ _Required_: Yes
 _Type_: <a href="vpc.md">Vpc</a>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/apachekafkacluster.md
+++ b/aws-kafkaconnect-connector/docs/apachekafkacluster.md
@@ -1,0 +1,46 @@
+# AWS::KafkaConnect::Connector ApacheKafkaCluster
+
+Details of how to connect to an Apache Kafka cluster.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#bootstrapservers" title="BootstrapServers">BootstrapServers</a>" : <i>String</i>,
+    "<a href="#vpc" title="Vpc">Vpc</a>" : <i><a href="vpc.md">Vpc</a></i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#bootstrapservers" title="BootstrapServers">BootstrapServers</a>: <i>String</i>
+<a href="#vpc" title="Vpc">Vpc</a>: <i><a href="vpc.md">Vpc</a></i>
+</pre>
+
+## Properties
+
+#### BootstrapServers
+
+The bootstrap servers string of the Apache Kafka cluster.
+
+_Required_: Yes
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Vpc
+
+Information about a VPC used with the connector.
+
+_Required_: Yes
+
+_Type_: <a href="vpc.md">Vpc</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/autoscaling.md
+++ b/aws-kafkaconnect-connector/docs/autoscaling.md
@@ -1,6 +1,6 @@
 # AWS::KafkaConnect::Connector AutoScaling
 
-Details about auto scaling of a connector. 
+Details about auto scaling of a connector.
 
 ## Syntax
 
@@ -81,4 +81,3 @@ _Type_: Integer
 _Allowed Values_: <code>1</code> | <code>2</code> | <code>4</code> | <code>8</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/autoscaling.md
+++ b/aws-kafkaconnect-connector/docs/autoscaling.md
@@ -1,0 +1,84 @@
+# AWS::KafkaConnect::Connector AutoScaling
+
+Details about auto scaling of a connector. 
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#maxworkercount" title="MaxWorkerCount">MaxWorkerCount</a>" : <i>Integer</i>,
+    "<a href="#minworkercount" title="MinWorkerCount">MinWorkerCount</a>" : <i>Integer</i>,
+    "<a href="#scaleinpolicy" title="ScaleInPolicy">ScaleInPolicy</a>" : <i><a href="scaleinpolicy.md">ScaleInPolicy</a></i>,
+    "<a href="#scaleoutpolicy" title="ScaleOutPolicy">ScaleOutPolicy</a>" : <i><a href="scaleoutpolicy.md">ScaleOutPolicy</a></i>,
+    "<a href="#mcucount" title="McuCount">McuCount</a>" : <i>Integer</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#maxworkercount" title="MaxWorkerCount">MaxWorkerCount</a>: <i>Integer</i>
+<a href="#minworkercount" title="MinWorkerCount">MinWorkerCount</a>: <i>Integer</i>
+<a href="#scaleinpolicy" title="ScaleInPolicy">ScaleInPolicy</a>: <i><a href="scaleinpolicy.md">ScaleInPolicy</a></i>
+<a href="#scaleoutpolicy" title="ScaleOutPolicy">ScaleOutPolicy</a>: <i><a href="scaleoutpolicy.md">ScaleOutPolicy</a></i>
+<a href="#mcucount" title="McuCount">McuCount</a>: <i>Integer</i>
+</pre>
+
+## Properties
+
+#### MaxWorkerCount
+
+The maximum number of workers for a connector.
+
+_Required_: Yes
+
+_Type_: Integer
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MinWorkerCount
+
+The minimum number of workers for a connector.
+
+_Required_: Yes
+
+_Type_: Integer
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### ScaleInPolicy
+
+Information about the scale in policy of the connector.
+
+_Required_: Yes
+
+_Type_: <a href="scaleinpolicy.md">ScaleInPolicy</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### ScaleOutPolicy
+
+Information about the scale out policy of the connector.
+
+_Required_: Yes
+
+_Type_: <a href="scaleoutpolicy.md">ScaleOutPolicy</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### McuCount
+
+Specifies how many MSK Connect Units (MCU) as the minimum scaling unit.
+
+_Required_: Yes
+
+_Type_: Integer
+
+_Allowed Values_: <code>1</code> | <code>2</code> | <code>4</code> | <code>8</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/capacity.md
+++ b/aws-kafkaconnect-connector/docs/capacity.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 #### AutoScaling
 
-Details about auto scaling of a connector. 
+Details about auto scaling of a connector.
 
 _Required_: Yes
 
@@ -43,4 +43,3 @@ _Required_: Yes
 _Type_: <a href="provisionedcapacity.md">ProvisionedCapacity</a>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/capacity.md
+++ b/aws-kafkaconnect-connector/docs/capacity.md
@@ -1,0 +1,46 @@
+# AWS::KafkaConnect::Connector Capacity
+
+Information about the capacity allocated to the connector.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#autoscaling" title="AutoScaling">AutoScaling</a>" : <i><a href="autoscaling.md">AutoScaling</a></i>,
+    "<a href="#provisionedcapacity" title="ProvisionedCapacity">ProvisionedCapacity</a>" : <i><a href="provisionedcapacity.md">ProvisionedCapacity</a></i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#autoscaling" title="AutoScaling">AutoScaling</a>: <i><a href="autoscaling.md">AutoScaling</a></i>
+<a href="#provisionedcapacity" title="ProvisionedCapacity">ProvisionedCapacity</a>: <i><a href="provisionedcapacity.md">ProvisionedCapacity</a></i>
+</pre>
+
+## Properties
+
+#### AutoScaling
+
+Details about auto scaling of a connector. 
+
+_Required_: Yes
+
+_Type_: <a href="autoscaling.md">AutoScaling</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### ProvisionedCapacity
+
+Details about a fixed capacity allocated to a connector.
+
+_Required_: Yes
+
+_Type_: <a href="provisionedcapacity.md">ProvisionedCapacity</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/cloudwatchlogslogdelivery.md
+++ b/aws-kafkaconnect-connector/docs/cloudwatchlogslogdelivery.md
@@ -43,4 +43,3 @@ _Required_: No
 _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/cloudwatchlogslogdelivery.md
+++ b/aws-kafkaconnect-connector/docs/cloudwatchlogslogdelivery.md
@@ -1,0 +1,46 @@
+# AWS::KafkaConnect::Connector CloudWatchLogsLogDelivery
+
+Details about delivering logs to Amazon CloudWatch Logs.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#enabled" title="Enabled">Enabled</a>" : <i>Boolean</i>,
+    "<a href="#loggroup" title="LogGroup">LogGroup</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#enabled" title="Enabled">Enabled</a>: <i>Boolean</i>
+<a href="#loggroup" title="LogGroup">LogGroup</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### Enabled
+
+Specifies whether the logs get sent to the specified CloudWatch Logs destination.
+
+_Required_: Yes
+
+_Type_: Boolean
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### LogGroup
+
+The CloudWatch log group that is the destination for log delivery.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/connectorconfiguration.md
+++ b/aws-kafkaconnect-connector/docs/connectorconfiguration.md
@@ -29,4 +29,3 @@ _Required_: No
 _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/connectorconfiguration.md
+++ b/aws-kafkaconnect-connector/docs/connectorconfiguration.md
@@ -1,0 +1,32 @@
+# AWS::KafkaConnect::Connector ConnectorConfiguration
+
+The configuration for the connector.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#.*" title=".*">.*</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#.*" title=".*">.*</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### \.*
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/customplugin.md
+++ b/aws-kafkaconnect-connector/docs/customplugin.md
@@ -45,4 +45,3 @@ _Required_: Yes
 _Type_: Integer
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/customplugin.md
+++ b/aws-kafkaconnect-connector/docs/customplugin.md
@@ -1,0 +1,48 @@
+# AWS::KafkaConnect::Connector CustomPlugin
+
+Details about a custom plugin.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#custompluginarn" title="CustomPluginArn">CustomPluginArn</a>" : <i>String</i>,
+    "<a href="#revision" title="Revision">Revision</a>" : <i>Integer</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#custompluginarn" title="CustomPluginArn">CustomPluginArn</a>: <i>String</i>
+<a href="#revision" title="Revision">Revision</a>: <i>Integer</i>
+</pre>
+
+## Properties
+
+#### CustomPluginArn
+
+The Amazon Resource Name (ARN) of the custom plugin to use.
+
+_Required_: Yes
+
+_Type_: String
+
+_Pattern_: <code>arn:(aws|aws-us-gov|aws-cn):kafkaconnect:.*</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Revision
+
+The revision of the custom plugin to use.
+
+_Required_: Yes
+
+_Type_: Integer
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/firehoselogdelivery.md
+++ b/aws-kafkaconnect-connector/docs/firehoselogdelivery.md
@@ -43,4 +43,3 @@ _Required_: Yes
 _Type_: Boolean
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/firehoselogdelivery.md
+++ b/aws-kafkaconnect-connector/docs/firehoselogdelivery.md
@@ -1,0 +1,46 @@
+# AWS::KafkaConnect::Connector FirehoseLogDelivery
+
+Details about delivering logs to Amazon Kinesis Data Firehose.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#deliverystream" title="DeliveryStream">DeliveryStream</a>" : <i>String</i>,
+    "<a href="#enabled" title="Enabled">Enabled</a>" : <i>Boolean</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#deliverystream" title="DeliveryStream">DeliveryStream</a>: <i>String</i>
+<a href="#enabled" title="Enabled">Enabled</a>: <i>Boolean</i>
+</pre>
+
+## Properties
+
+#### DeliveryStream
+
+The Kinesis Data Firehose delivery stream that is the destination for log delivery.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Enabled
+
+Specifies whether the logs get sent to the specified Kinesis Data Firehose delivery stream.
+
+_Required_: Yes
+
+_Type_: Boolean
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/kafkacluster.md
+++ b/aws-kafkaconnect-connector/docs/kafkacluster.md
@@ -1,0 +1,34 @@
+# AWS::KafkaConnect::Connector KafkaCluster
+
+Details of how to connect to the Kafka cluster.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#apachekafkacluster" title="ApacheKafkaCluster">ApacheKafkaCluster</a>" : <i><a href="apachekafkacluster.md">ApacheKafkaCluster</a></i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#apachekafkacluster" title="ApacheKafkaCluster">ApacheKafkaCluster</a>: <i><a href="apachekafkacluster.md">ApacheKafkaCluster</a></i>
+</pre>
+
+## Properties
+
+#### ApacheKafkaCluster
+
+Details of how to connect to an Apache Kafka cluster.
+
+_Required_: Yes
+
+_Type_: <a href="apachekafkacluster.md">ApacheKafkaCluster</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/kafkacluster.md
+++ b/aws-kafkaconnect-connector/docs/kafkacluster.md
@@ -31,4 +31,3 @@ _Required_: Yes
 _Type_: <a href="apachekafkacluster.md">ApacheKafkaCluster</a>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/kafkaclusterclientauthentication.md
+++ b/aws-kafkaconnect-connector/docs/kafkaclusterclientauthentication.md
@@ -33,4 +33,3 @@ _Type_: String
 _Allowed Values_: <code>NONE</code> | <code>IAM</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/kafkaclusterclientauthentication.md
+++ b/aws-kafkaconnect-connector/docs/kafkaclusterclientauthentication.md
@@ -1,0 +1,36 @@
+# AWS::KafkaConnect::Connector KafkaClusterClientAuthentication
+
+Details of the client authentication used by the Kafka cluster.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#authenticationtype" title="AuthenticationType">AuthenticationType</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#authenticationtype" title="AuthenticationType">AuthenticationType</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### AuthenticationType
+
+The type of client authentication used to connect to the Kafka cluster. Value NONE means that no client authentication is used.
+
+_Required_: Yes
+
+_Type_: String
+
+_Allowed Values_: <code>NONE</code> | <code>IAM</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/kafkaclusterencryptionintransit.md
+++ b/aws-kafkaconnect-connector/docs/kafkaclusterencryptionintransit.md
@@ -1,0 +1,36 @@
+# AWS::KafkaConnect::Connector KafkaClusterEncryptionInTransit
+
+Details of encryption in transit to the Kafka cluster.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#encryptiontype" title="EncryptionType">EncryptionType</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#encryptiontype" title="EncryptionType">EncryptionType</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### EncryptionType
+
+The type of encryption in transit to the Kafka cluster.
+
+_Required_: Yes
+
+_Type_: String
+
+_Allowed Values_: <code>PLAINTEXT</code> | <code>TLS</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/kafkaclusterencryptionintransit.md
+++ b/aws-kafkaconnect-connector/docs/kafkaclusterencryptionintransit.md
@@ -33,4 +33,3 @@ _Type_: String
 _Allowed Values_: <code>PLAINTEXT</code> | <code>TLS</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/logdelivery.md
+++ b/aws-kafkaconnect-connector/docs/logdelivery.md
@@ -1,0 +1,34 @@
+# AWS::KafkaConnect::Connector LogDelivery
+
+Details of what logs are delivered and where they are delivered.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#workerlogdelivery" title="WorkerLogDelivery">WorkerLogDelivery</a>" : <i><a href="workerlogdelivery.md">WorkerLogDelivery</a></i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#workerlogdelivery" title="WorkerLogDelivery">WorkerLogDelivery</a>: <i><a href="workerlogdelivery.md">WorkerLogDelivery</a></i>
+</pre>
+
+## Properties
+
+#### WorkerLogDelivery
+
+Specifies where worker logs are delivered.
+
+_Required_: Yes
+
+_Type_: <a href="workerlogdelivery.md">WorkerLogDelivery</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/logdelivery.md
+++ b/aws-kafkaconnect-connector/docs/logdelivery.md
@@ -31,4 +31,3 @@ _Required_: Yes
 _Type_: <a href="workerlogdelivery.md">WorkerLogDelivery</a>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/plugin.md
+++ b/aws-kafkaconnect-connector/docs/plugin.md
@@ -1,0 +1,34 @@
+# AWS::KafkaConnect::Connector Plugin
+
+Details about a Kafka Connect plugin which will be used with the connector.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#customplugin" title="CustomPlugin">CustomPlugin</a>" : <i><a href="customplugin.md">CustomPlugin</a></i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#customplugin" title="CustomPlugin">CustomPlugin</a>: <i><a href="customplugin.md">CustomPlugin</a></i>
+</pre>
+
+## Properties
+
+#### CustomPlugin
+
+Details about a custom plugin.
+
+_Required_: Yes
+
+_Type_: <a href="customplugin.md">CustomPlugin</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/plugin.md
+++ b/aws-kafkaconnect-connector/docs/plugin.md
@@ -31,4 +31,3 @@ _Required_: Yes
 _Type_: <a href="customplugin.md">CustomPlugin</a>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/provisionedcapacity.md
+++ b/aws-kafkaconnect-connector/docs/provisionedcapacity.md
@@ -1,0 +1,48 @@
+# AWS::KafkaConnect::Connector ProvisionedCapacity
+
+Details about a fixed capacity allocated to a connector.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#mcucount" title="McuCount">McuCount</a>" : <i>Integer</i>,
+    "<a href="#workercount" title="WorkerCount">WorkerCount</a>" : <i>Integer</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#mcucount" title="McuCount">McuCount</a>: <i>Integer</i>
+<a href="#workercount" title="WorkerCount">WorkerCount</a>: <i>Integer</i>
+</pre>
+
+## Properties
+
+#### McuCount
+
+Specifies how many MSK Connect Units (MCU) are allocated to the connector.
+
+_Required_: No
+
+_Type_: Integer
+
+_Allowed Values_: <code>1</code> | <code>2</code> | <code>4</code> | <code>8</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### WorkerCount
+
+Number of workers for a connector.
+
+_Required_: Yes
+
+_Type_: Integer
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/provisionedcapacity.md
+++ b/aws-kafkaconnect-connector/docs/provisionedcapacity.md
@@ -45,4 +45,3 @@ _Required_: Yes
 _Type_: Integer
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/s3logdelivery.md
+++ b/aws-kafkaconnect-connector/docs/s3logdelivery.md
@@ -55,4 +55,3 @@ _Required_: No
 _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/s3logdelivery.md
+++ b/aws-kafkaconnect-connector/docs/s3logdelivery.md
@@ -1,0 +1,58 @@
+# AWS::KafkaConnect::Connector S3LogDelivery
+
+Details about delivering logs to Amazon S3.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#bucket" title="Bucket">Bucket</a>" : <i>String</i>,
+    "<a href="#enabled" title="Enabled">Enabled</a>" : <i>Boolean</i>,
+    "<a href="#prefix" title="Prefix">Prefix</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#bucket" title="Bucket">Bucket</a>: <i>String</i>
+<a href="#enabled" title="Enabled">Enabled</a>: <i>Boolean</i>
+<a href="#prefix" title="Prefix">Prefix</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### Bucket
+
+The name of the S3 bucket that is the destination for log delivery.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Enabled
+
+Specifies whether the logs get sent to the specified Amazon S3 destination.
+
+_Required_: Yes
+
+_Type_: Boolean
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Prefix
+
+The S3 prefix that is the destination for log delivery.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/scaleinpolicy.md
+++ b/aws-kafkaconnect-connector/docs/scaleinpolicy.md
@@ -1,0 +1,34 @@
+# AWS::KafkaConnect::Connector ScaleInPolicy
+
+Information about the scale in policy of the connector.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#cpuutilizationpercentage" title="CpuUtilizationPercentage">CpuUtilizationPercentage</a>" : <i>Integer</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#cpuutilizationpercentage" title="CpuUtilizationPercentage">CpuUtilizationPercentage</a>: <i>Integer</i>
+</pre>
+
+## Properties
+
+#### CpuUtilizationPercentage
+
+Specifies the CPU utilization percentage threshold at which connector scale in should trigger.
+
+_Required_: Yes
+
+_Type_: Integer
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/scaleinpolicy.md
+++ b/aws-kafkaconnect-connector/docs/scaleinpolicy.md
@@ -31,4 +31,3 @@ _Required_: Yes
 _Type_: Integer
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/scaleoutpolicy.md
+++ b/aws-kafkaconnect-connector/docs/scaleoutpolicy.md
@@ -1,0 +1,34 @@
+# AWS::KafkaConnect::Connector ScaleOutPolicy
+
+Information about the scale out policy of the connector.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#cpuutilizationpercentage" title="CpuUtilizationPercentage">CpuUtilizationPercentage</a>" : <i>Integer</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#cpuutilizationpercentage" title="CpuUtilizationPercentage">CpuUtilizationPercentage</a>: <i>Integer</i>
+</pre>
+
+## Properties
+
+#### CpuUtilizationPercentage
+
+Specifies the CPU utilization percentage threshold at which connector scale out should trigger.
+
+_Required_: Yes
+
+_Type_: Integer
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/scaleoutpolicy.md
+++ b/aws-kafkaconnect-connector/docs/scaleoutpolicy.md
@@ -31,4 +31,3 @@ _Required_: Yes
 _Type_: Integer
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/vpc.md
+++ b/aws-kafkaconnect-connector/docs/vpc.md
@@ -1,0 +1,48 @@
+# AWS::KafkaConnect::Connector Vpc
+
+Information about a VPC used with the connector.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#securitygroups" title="SecurityGroups">SecurityGroups</a>" : <i>[ String, ... ]</i>,
+    "<a href="#subnets" title="Subnets">Subnets</a>" : <i>[ String, ... ]</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#securitygroups" title="SecurityGroups">SecurityGroups</a>: <i>
+      - String</i>
+<a href="#subnets" title="Subnets">Subnets</a>: <i>
+      - String</i>
+</pre>
+
+## Properties
+
+#### SecurityGroups
+
+The AWS security groups to associate with the elastic network interfaces in order to specify what the connector has access to.
+
+_Required_: Yes
+
+_Type_: List of String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Subnets
+
+The list of subnets to connect to in the virtual private cloud (VPC). AWS creates elastic network interfaces inside these subnets.
+
+_Required_: Yes
+
+_Type_: List of String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/vpc.md
+++ b/aws-kafkaconnect-connector/docs/vpc.md
@@ -45,4 +45,3 @@ _Required_: Yes
 _Type_: List of String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/workerconfiguration.md
+++ b/aws-kafkaconnect-connector/docs/workerconfiguration.md
@@ -45,4 +45,3 @@ _Type_: String
 _Pattern_: <code>arn:(aws|aws-us-gov|aws-cn):kafkaconnect:.*</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/workerconfiguration.md
+++ b/aws-kafkaconnect-connector/docs/workerconfiguration.md
@@ -1,0 +1,48 @@
+# AWS::KafkaConnect::Connector WorkerConfiguration
+
+Specifies the worker configuration to use with the connector.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#revision" title="Revision">Revision</a>" : <i>Integer</i>,
+    "<a href="#workerconfigurationarn" title="WorkerConfigurationArn">WorkerConfigurationArn</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#revision" title="Revision">Revision</a>: <i>Integer</i>
+<a href="#workerconfigurationarn" title="WorkerConfigurationArn">WorkerConfigurationArn</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### Revision
+
+The revision of the worker configuration to use.
+
+_Required_: Yes
+
+_Type_: Integer
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### WorkerConfigurationArn
+
+The Amazon Resource Name (ARN) of the worker configuration to use.
+
+_Required_: Yes
+
+_Type_: String
+
+_Pattern_: <code>arn:(aws|aws-us-gov|aws-cn):kafkaconnect:.*</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/docs/workerlogdelivery.md
+++ b/aws-kafkaconnect-connector/docs/workerlogdelivery.md
@@ -55,4 +55,3 @@ _Required_: No
 _Type_: <a href="s3logdelivery.md">S3LogDelivery</a>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-kafkaconnect-connector/docs/workerlogdelivery.md
+++ b/aws-kafkaconnect-connector/docs/workerlogdelivery.md
@@ -1,0 +1,58 @@
+# AWS::KafkaConnect::Connector WorkerLogDelivery
+
+Specifies where worker logs are delivered.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#cloudwatchlogs" title="CloudWatchLogs">CloudWatchLogs</a>" : <i><a href="cloudwatchlogslogdelivery.md">CloudWatchLogsLogDelivery</a></i>,
+    "<a href="#firehose" title="Firehose">Firehose</a>" : <i><a href="firehoselogdelivery.md">FirehoseLogDelivery</a></i>,
+    "<a href="#s3" title="S3">S3</a>" : <i><a href="s3logdelivery.md">S3LogDelivery</a></i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#cloudwatchlogs" title="CloudWatchLogs">CloudWatchLogs</a>: <i><a href="cloudwatchlogslogdelivery.md">CloudWatchLogsLogDelivery</a></i>
+<a href="#firehose" title="Firehose">Firehose</a>: <i><a href="firehoselogdelivery.md">FirehoseLogDelivery</a></i>
+<a href="#s3" title="S3">S3</a>: <i><a href="s3logdelivery.md">S3LogDelivery</a></i>
+</pre>
+
+## Properties
+
+#### CloudWatchLogs
+
+Details about delivering logs to Amazon CloudWatch Logs.
+
+_Required_: No
+
+_Type_: <a href="cloudwatchlogslogdelivery.md">CloudWatchLogsLogDelivery</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Firehose
+
+Details about delivering logs to Amazon Kinesis Data Firehose.
+
+_Required_: No
+
+_Type_: <a href="firehoselogdelivery.md">FirehoseLogDelivery</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### S3
+
+Details about delivering logs to Amazon S3.
+
+_Required_: No
+
+_Type_: <a href="s3logdelivery.md">S3LogDelivery</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-kafkaconnect-connector/resource-role.yaml
+++ b/aws-kafkaconnect-connector/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/AWS-KafkaConnect-Connector/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,7 +5,8 @@ phases:
         java: openjdk8
         python: 3.7
     commands:
-      -  pip install pyyaml --upgrade
+      -  pip install --upgrade 'pyyaml~=5.1'
+      -  pip install boto3 --upgrade
       -  pip install --upgrade 'six==1.15.0'
       -  pip install pre-commit cloudformation-cli-java-plugin
   build:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1592

*Description of changes:*
In this pull request, we update the replacement strategy of the `AWS::KafkaConnect::Connector` resource to be `delete_then_create`. Moreover, we scope down on the execution role and add the corresponding docs folder, both of which are automatically generated via `cfn generate`.

The change was tested by first reproducing the behavior observed in https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1592, and then verifying that with the change introduced in this pull request, the relevant connector resource first gets deleted, and then gets recreated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
